### PR TITLE
Rewrite startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ FROM yeasy/mongo-connector:latest
 ```
 
 ## Local Run
-By default, it will connect mongo node ($MONGO or the mongo host) and elasticsearch node ($ELASTICSEARCH or the elasticsearch host).
+By default, it will connect mongo node (`$MONGO` or the mongo host, on port `$MONGOPORT` or 27017) and elasticsearch node (`$ELASTICSEARCH` or the elasticsearch host, on port $ELASTICPORT or 9200).
 
 Boot two containers with name mongo (config to cluster) and elasticsearch.
 ```sh

--- a/startup.sh
+++ b/startup.sh
@@ -7,7 +7,7 @@ elasticport="${ELASTICPORT:-9200}"
 
 
 function _mongo() {
-    mongo --quiet --host ${MONGO} <<EOF
+    mongo --quiet --host ${mongo} --port ${mongoport} <<EOF
     $@
 EOF
 }


### PR DESCRIPTION
I needed to change ports for mongo and elastic so I updated the `startup.sh`.

I also had to move the env vars declaration to the top of the file so that it's leveraged in the whole script.

I also didn't like that it drops a file to cwd, so I added a local function to call mongo and changed a way how it compares results. Let me know in case of any doubts or issues.
